### PR TITLE
Use namespace ripsaw

### DIFF
--- a/roles/okd_setup/tasks/main.yml
+++ b/roles/okd_setup/tasks/main.yml
@@ -16,12 +16,12 @@
   command: kubectl config use-context {{ okd_admin_context.stdout }}
   when: okd_admin_context is succeeded
 
-- name: create the namespace benchmark
-  command: kubectl create namespace benchmark
+- name: create the namespace ripsaw
+  command: kubectl create namespace ripsaw
   ignore_errors: yes
 
 - name: set to admin context
-  command: kubectl config set-context ripsaw --namespace=benchmark --cluster={{ okd_cluster_name.stdout }} --user={{ okd_admin_user.stdout }}
+  command: kubectl config set-context ripsaw --namespace=ripsaw --cluster={{ okd_cluster_name.stdout }} --user={{ okd_admin_user.stdout }}
   register: ripsaw_context
   when: okd_admin_user is succeeded and okd_cluster_name is succeeded
 


### PR DESCRIPTION
Following https://github.com/dustinblack/benchmark-operator/pull/5 , we'll need to update to use ripsaw namespace